### PR TITLE
Add file extension so the downloaded artefact

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -5250,6 +5250,7 @@ const tool_cache_1 = __nccwpck_require__(784);
 const core_1 = __nccwpck_require__(186);
 const http_client_1 = __nccwpck_require__(925);
 const path_1 = __nccwpck_require__(622);
+const promises_1 = __nccwpck_require__(225);
 const osPlatform = os.platform();
 const platform = osPlatform === 'win32' ? 'win' : osPlatform === 'darwin' ? 'osx' : 'linux';
 const ext = osPlatform === 'win32' ? 'zip' : 'tar.gz';
@@ -5291,13 +5292,16 @@ function installOctopusCli(version) {
         (0, core_1.info)(`⬇️ Downloading Octopus CLI ${octopusCliDownload.version}...`);
         const downloadPath = yield (0, tool_cache_1.downloadTool)(octopusCliDownload.url);
         (0, core_1.debug)(`Downloaded to ${downloadPath}`);
+        yield (0, promises_1.rename)(`${downloadPath}`, `${downloadPath}.${ext}`);
+        const downloadPathRenamed = `${downloadPath}.${ext}`;
+        (0, core_1.debug)(`Added extension ${downloadPathRenamed}`);
         (0, core_1.info)(`📦 Extracting Octopus CLI ${octopusCliDownload.version}...`);
         let extPath = '';
         if (osPlatform === 'win32') {
-            extPath = yield (0, tool_cache_1.extractZip)(downloadPath);
+            extPath = yield (0, tool_cache_1.extractZip)(downloadPathRenamed);
         }
         else if (octopusCliDownload.url.endsWith('.gz')) {
-            extPath = yield (0, tool_cache_1.extractTar)(downloadPath);
+            extPath = yield (0, tool_cache_1.extractTar)(downloadPathRenamed);
         }
         (0, core_1.debug)(`Extracted to ${extPath}`);
         const cachePath = yield (0, tool_cache_1.cacheDir)(extPath, 'octo', version);
@@ -5350,6 +5354,14 @@ module.exports = require("events");
 
 "use strict";
 module.exports = require("fs");
+
+/***/ }),
+
+/***/ 225:
+/***/ ((module) => {
+
+"use strict";
+module.exports = require("fs/promises");
 
 /***/ }),
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -5250,7 +5250,7 @@ const tool_cache_1 = __nccwpck_require__(784);
 const core_1 = __nccwpck_require__(186);
 const http_client_1 = __nccwpck_require__(925);
 const path_1 = __nccwpck_require__(622);
-const promises_1 = __nccwpck_require__(225);
+const fs_1 = __nccwpck_require__(747);
 const osPlatform = os.platform();
 const platform = osPlatform === 'win32' ? 'win' : osPlatform === 'darwin' ? 'osx' : 'linux';
 const ext = osPlatform === 'win32' ? 'zip' : 'tar.gz';
@@ -5292,7 +5292,10 @@ function installOctopusCli(version) {
         (0, core_1.info)(`⬇️ Downloading Octopus CLI ${octopusCliDownload.version}...`);
         const downloadPath = yield (0, tool_cache_1.downloadTool)(octopusCliDownload.url);
         (0, core_1.debug)(`Downloaded to ${downloadPath}`);
-        yield (0, promises_1.rename)(`${downloadPath}`, `${downloadPath}.${ext}`);
+        (0, fs_1.rename)(`${downloadPath}`, `${downloadPath}.${ext}`, err => {
+            if (err)
+                throw err;
+        });
         const downloadPathRenamed = `${downloadPath}.${ext}`;
         (0, core_1.debug)(`Added extension ${downloadPathRenamed}`);
         (0, core_1.info)(`📦 Extracting Octopus CLI ${octopusCliDownload.version}...`);
@@ -5354,14 +5357,6 @@ module.exports = require("events");
 
 "use strict";
 module.exports = require("fs");
-
-/***/ }),
-
-/***/ 225:
-/***/ ((module) => {
-
-"use strict";
-module.exports = require("fs/promises");
 
 /***/ }),
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "install-octopus-cli-action",
-  "version": "1.1.7",
+  "version": "1.1.7-fix01",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "install-octopus-cli-action",
-      "version": "1.1.7",
+      "version": "1.1.7-fix01",
       "license": "Apache-2.0",
       "dependencies": {
         "@actions/core": "^1.5.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
       },
       "devDependencies": {
         "@types/jest": "^27.0.1",
-        "@types/node": "^16.9.2",
+        "@types/node": "^16.10.2",
         "@types/tmp": "^0.2.1",
         "@typescript-eslint/parser": "^4.31.1",
         "@vercel/ncc": "^0.31.1",
@@ -1206,9 +1206,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "16.9.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.9.2.tgz",
-      "integrity": "sha512-ZHty/hKoOLZvSz6BtP1g7tc7nUeJhoCf3flLjh8ZEv1vFKBWHXcnMbJMyN/pftSljNyy0kNW/UqI3DccnBnZ8w==",
+      "version": "16.10.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.10.2.tgz",
+      "integrity": "sha512-zCclL4/rx+W5SQTzFs9wyvvyCwoK9QtBpratqz2IYJ3O8Umrn0m3nsTv0wQBk9sRGpvUe9CwPDrQFB10f1FIjQ==",
       "dev": true
     },
     "node_modules/@types/prettier": {
@@ -7429,9 +7429,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "16.9.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.9.2.tgz",
-      "integrity": "sha512-ZHty/hKoOLZvSz6BtP1g7tc7nUeJhoCf3flLjh8ZEv1vFKBWHXcnMbJMyN/pftSljNyy0kNW/UqI3DccnBnZ8w==",
+      "version": "16.10.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.10.2.tgz",
+      "integrity": "sha512-zCclL4/rx+W5SQTzFs9wyvvyCwoK9QtBpratqz2IYJ3O8Umrn0m3nsTv0wQBk9sRGpvUe9CwPDrQFB10f1FIjQ==",
       "dev": true
     },
     "@types/prettier": {

--- a/package.json
+++ b/package.json
@@ -70,5 +70,5 @@
     "postbuild": "ncc build -o dist",
     "test": "jest"
   },
-  "version": "1.1.7-fix"
+  "version": "1.1.7-fix01"
 }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "description": "GitHub Action to Install the Octopus CLI",
   "devDependencies": {
     "@types/jest": "^27.0.1",
-    "@types/node": "^16.9.2",
+    "@types/node": "^16.10.2",
     "@types/tmp": "^0.2.1",
     "@typescript-eslint/parser": "^4.31.1",
     "@vercel/ncc": "^0.31.1",
@@ -70,5 +70,5 @@
     "postbuild": "ncc build -o dist",
     "test": "jest"
   },
-  "version": "1.1.7"
+  "version": "1.1.7-fix"
 }

--- a/src/octopus-cli.ts
+++ b/src/octopus-cli.ts
@@ -9,6 +9,7 @@ import {debug, info, setFailed} from '@actions/core'
 import {Downloads} from './download'
 import {HttpClient} from '@actions/http-client'
 import {join} from 'path'
+import {rename} from 'fs/promises'
 
 const osPlatform: string = os.platform()
 const platform: string =
@@ -67,12 +68,16 @@ export async function installOctopusCli(version: string): Promise<string> {
   const downloadPath: string = await downloadTool(octopusCliDownload.url)
   debug(`Downloaded to ${downloadPath}`)
 
+  await rename(`${downloadPath}`, `${downloadPath}.${ext}`)
+  const downloadPathRenamed = `${downloadPath}.${ext}`
+  debug(`Added extension ${downloadPathRenamed}`)
+
   info(`📦 Extracting Octopus CLI ${octopusCliDownload.version}...`)
   let extPath = ''
   if (osPlatform === 'win32') {
-    extPath = await extractZip(downloadPath)
+    extPath = await extractZip(downloadPathRenamed)
   } else if (octopusCliDownload.url.endsWith('.gz')) {
-    extPath = await extractTar(downloadPath)
+    extPath = await extractTar(downloadPathRenamed)
   }
   debug(`Extracted to ${extPath}`)
 

--- a/src/octopus-cli.ts
+++ b/src/octopus-cli.ts
@@ -68,7 +68,9 @@ export async function installOctopusCli(version: string): Promise<string> {
   const downloadPath: string = await downloadTool(octopusCliDownload.url)
   debug(`Downloaded to ${downloadPath}`)
 
-  await rename(`${downloadPath}`, `${downloadPath}.${ext}`)
+  rename(`${downloadPath}`, `${downloadPath}.${ext}`, err => {
+    if (err) throw err
+  })
   const downloadPathRenamed = `${downloadPath}.${ext}`
   debug(`Added extension ${downloadPathRenamed}`)
 

--- a/src/octopus-cli.ts
+++ b/src/octopus-cli.ts
@@ -9,7 +9,7 @@ import {debug, info, setFailed} from '@actions/core'
 import {Downloads} from './download'
 import {HttpClient} from '@actions/http-client'
 import {join} from 'path'
-import {rename} from 'fs/promises'
+import {rename} from 'fs'
 
 const osPlatform: string = os.platform()
 const platform: string =


### PR DESCRIPTION
This PR shows an example fix for #139 

It adds the extension (.ZIP or .tar.gz) to the downloaded artefact and ExtractZip is no longer failing

