### PR TITLE
Specify destination for downloaded file

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,12 +11,14 @@
       "dependencies": {
         "@actions/core": "^1.6.0",
         "@actions/http-client": "^1.0.11",
-        "@actions/tool-cache": "^1.7.1"
+        "@actions/tool-cache": "^1.7.1",
+        "uuid": "^8.3.2"
       },
       "devDependencies": {
         "@types/jest": "^27.4.0",
         "@types/node": "^17.0.10",
         "@types/tmp": "^0.2.3",
+        "@types/uuid": "^8.3.4",
         "@typescript-eslint/eslint-plugin": "^5.10.0",
         "@typescript-eslint/parser": "^5.10.0",
         "@vercel/ncc": "^0.33.1",
@@ -71,6 +73,15 @@
         "@actions/io": "^1.1.1",
         "semver": "^6.1.0",
         "uuid": "^3.3.2"
+      }
+    },
+    "node_modules/@actions/tool-cache/node_modules/uuid": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+      "bin": {
+        "uuid": "bin/uuid"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1187,6 +1198,12 @@
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/@types/tmp/-/tmp-0.2.3.tgz",
       "integrity": "sha512-dDZH/tXzwjutnuk4UacGgFRwV+JSLaXL1ikvidfJprkb7L9Nx1njcRHHmi3Dsvt7pgqqTEeucQuOrWHPFgzVHA==",
+      "dev": true
+    },
+    "node_modules/@types/uuid": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.4.tgz",
+      "integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==",
       "dev": true
     },
     "node_modules/@types/yargs": {
@@ -5168,12 +5185,11 @@
       }
     },
     "node_modules/uuid": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
       "bin": {
-        "uuid": "bin/uuid"
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/v8-compile-cache": {
@@ -5449,6 +5465,13 @@
         "@actions/io": "^1.1.1",
         "semver": "^6.1.0",
         "uuid": "^3.3.2"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+        }
       }
     },
     "@babel/code-frame": {
@@ -6344,6 +6367,12 @@
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/@types/tmp/-/tmp-0.2.3.tgz",
       "integrity": "sha512-dDZH/tXzwjutnuk4UacGgFRwV+JSLaXL1ikvidfJprkb7L9Nx1njcRHHmi3Dsvt7pgqqTEeucQuOrWHPFgzVHA==",
+      "dev": true
+    },
+    "@types/uuid": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.4.tgz",
+      "integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==",
       "dev": true
     },
     "@types/yargs": {
@@ -9234,9 +9263,9 @@
       }
     },
     "uuid": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
     },
     "v8-compile-cache": {
       "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -6,13 +6,15 @@
   "dependencies": {
     "@actions/core": "^1.6.0",
     "@actions/http-client": "^1.0.11",
-    "@actions/tool-cache": "^1.7.1"
+    "@actions/tool-cache": "^1.7.1",
+    "uuid": "^8.3.2"
   },
   "description": "GitHub Action to Install the Octopus CLI",
   "devDependencies": {
     "@types/jest": "^27.4.0",
     "@types/node": "^17.0.10",
     "@types/tmp": "^0.2.3",
+    "@types/uuid": "^8.3.4",
     "@typescript-eslint/eslint-plugin": "^5.10.0",
     "@typescript-eslint/parser": "^5.10.0",
     "@vercel/ncc": "^0.33.1",

--- a/src/octopus-cli.ts
+++ b/src/octopus-cli.ts
@@ -1,4 +1,5 @@
 import * as os from 'os'
+import {promises as fs} from 'fs'
 import {
   cacheDir,
   downloadTool,
@@ -8,7 +9,8 @@ import {
 import {debug, info, setFailed} from '@actions/core'
 import {Downloads} from './download'
 import {HttpClient} from '@actions/http-client'
-import {join} from 'path'
+import {join, dirname} from 'path'
+import {v4} from 'uuid'
 
 const osPlatform: string = os.platform()
 const platform: string =
@@ -64,7 +66,9 @@ export async function installOctopusCli(version: string): Promise<string> {
   const octopusCliDownload = await getDownloadUrl(version)
 
   info(`⬇️ Downloading Octopus CLI ${octopusCliDownload.version}...`)
-  const downloadPath: string = await downloadTool(octopusCliDownload.url)
+  const dest = join(process.env['RUNNER_TEMP'] || '', `${v4()}.${ext}`)
+  await fs.mkdir(dirname(dest), {recursive: true})
+  const downloadPath: string = await downloadTool(octopusCliDownload.url, dest)
   debug(`Downloaded to ${downloadPath}`)
 
   info(`📦 Extracting Octopus CLI ${octopusCliDownload.version}...`)


### PR DESCRIPTION
It seems the call to `downloadTool` in Windows uses PowerShell to extract the zip file.
The Powershell script tries different ways to extract the downloaded artifact, first attempts extraction with `ExtractToDirectory`(dotnet), if this fails attempt `Expand-Archive` (PowerShell cmdlet) see https://github.com/actions/toolkit/blob/daf8bb00606d37ee2431d9b1596b88513dcf9c59/packages/tool-cache/src/tool-cache.ts#L353

Unfortunately, it seems `Expand-Archive` (powershell cmdlet) needs an extension on the filename for it to work.

This PR ensures the call to `downloadTool` specifies a destination path with an extension.

Fixes https://github.com/OctopusDeploy/install-octopus-cli-action/issues/139