### PR TITLE
Bump to node16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -12,5 +12,5 @@ inputs:
     required: false
 
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'


### PR DESCRIPTION
Bumps the action to use node16 rather than node12 as per: [GitHub Depreciation Notice](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/) 

Tests are passing locally using node v16.13.1 + ubuntu latest has node v16.17.1