### PR TITLE
Using releases.json stored in repository to avoid rate limiting

### DIFF
--- a/src/octopus-cli.ts
+++ b/src/octopus-cli.ts
@@ -15,7 +15,7 @@ import {OctopusCLIVersionFetcher} from './octopusCLIVersionFetcher'
 const osPlatform: string = os.platform()
 const osArch: string = os.arch()
 const ext: string = osPlatform === 'win32' ? 'zip' : 'tar.gz'
-const releasesUrl = `https://api.github.com/repos/OctopusDeploy/cli/releases`
+const releasesUrl = `https://raw.githubusercontent.com/OctopusDeploy/cli/main/releases.json`
 const http: HttpClient = new HttpClient(
   'action-install-octopus-cli',
   undefined,


### PR DESCRIPTION
Customers are being rate-limited when using the Install Octopus CLI GitHub Action, to avoid this entirely and avoid the dependency on an authenticated token, we've opted to store releases in the repository itself

Read releases from the non-rate limited releases list stored in the repository at`https://raw.githubusercontent.com/OctopusDeploy/cli/main/releases.json`. This change is to be merged following https://github.com/OctopusDeploy/cli/pull/228/files

[[sc-41298]](https://app.shortcut.com/octopusdeploy/story/41298/cli-installer-for-gha-actions-and-octotfs-is-hitting-github-api-limits)